### PR TITLE
bugfix where pseudo metabolites where not assigned correctly (#12, #33), guard for complex GPR rules (#32)

### DIFF
--- a/autopacmen/submodules/create_smoment_model_reaction_wise.py
+++ b/autopacmen/submodules/create_smoment_model_reaction_wise.py
@@ -183,6 +183,7 @@ def create_smoment_model_reaction_wise(
 
     # Main loop :D, add enzyme constraints to reactions \o/
     for model_reaction_id in model_reaction_ids:
+        
         # Get the reaction and split the ID at the ID addition
         reaction = model.reactions.get_by_id(model_reaction_id)
         splitted_id = reaction.id.split(id_addition)
@@ -192,9 +193,9 @@ def create_smoment_model_reaction_wise(
             continue
         # Take the reaction ID from the first part of the split
         reaction_id = splitted_id[0]
+
         # Remove GPRSPLIT name addition from reactions with measured protein concentrations
-        if "_GPRSPLIT_" in reaction_id:
-            reaction_id = reaction_id.split("_GPRSPLIT_")[0]
+        original_reaction_id = reaction_id.split("_GPRSPLIT_")[0]
 
         # If the reaction has no associated enzyme stoichiometries, ignore it
         if reaction_id not in list(reaction_id_gene_rules_mapping.keys()):
@@ -204,7 +205,7 @@ def create_smoment_model_reaction_wise(
         if gene_rule == [""]:
             continue
         # If the reaction is manually excluded, ignore it
-        if reaction_id in excluded_reactions:
+        if original_reaction_id in excluded_reactions:
             continue
 
         # Check if all proteins in the reaction's gene rule have a found mass
@@ -226,9 +227,9 @@ def create_smoment_model_reaction_wise(
             continue
 
         # Retrieve the reaction's forward and reverse kcats from the given reaction<->kcat database
-        if reaction_id in reactions_kcat_mapping_database.keys():
-            forward_kcat = reactions_kcat_mapping_database[reaction_id]["forward"]
-            reverse_kcat = reactions_kcat_mapping_database[reaction_id]["reverse"]
+        if original_reaction_id in reactions_kcat_mapping_database.keys():
+            forward_kcat = reactions_kcat_mapping_database[original_reaction_id]["forward"]
+            reverse_kcat = reactions_kcat_mapping_database[original_reaction_id]["reverse"]
         # If the reaction is not in the database, set the default kcat
         else:
             forward_kcat = default_kcat
@@ -258,12 +259,10 @@ def create_smoment_model_reaction_wise(
         stoichiometries: List[float] = []
         # List of enzyme names and stoichiometries (semicolon-separated) for a console report
         stoichiometry_enzyme_name_list: List[str] = []
+
         for isozyme_id in gene_rule:
             # If it's not a complex :O...
             if type(isozyme_id) is str:
-                # ...get the reaction ID without the additions...
-                reaction_id = reaction_id.split("_TG_")[0]
-
                 # ...get the number of units for this protein...
                 number_units = reaction_id_gene_rules_protein_stoichiometry_mapping[
                     reaction_id
@@ -303,10 +302,8 @@ def create_smoment_model_reaction_wise(
 
                 # ...go through each single ID of the complex...
                 stoichiometry_enzyme_name_list.append("")
-                for single_id in isozyme_id:
-                    # ...get the reaction ID without additions...
-                    reaction_id = reaction_id.split("_TG_")[0]
 
+                for single_id in isozyme_id:
                     # ...get the number of units for this protein...
                     number_units = reaction_id_gene_rules_protein_stoichiometry_mapping[
                         reaction_id

--- a/autopacmen/submodules/helper_create_model.py
+++ b/autopacmen/submodules/helper_create_model.py
@@ -166,6 +166,12 @@ def apply_scenario_on_model(
         reactions_to_set_up = scenario["setup"].keys()
         for reaction_to_set_up in reactions_to_set_up:
             reaction_setup = scenario["setup"][reaction_to_set_up]
+
+            if "lower_bound" in reaction_setup.keys() and "upper_bound" in reaction_setup.keys():
+                # if old upper bound is lower than new lower bound, there will be an error --> assign both bounds at once if present
+                model.reactions.get_by_id(reaction_to_set_up).bounds = (reaction_setup["lower_bound"], reaction_setup["upper_bound"])
+                continue
+
             if "lower_bound" in reaction_setup.keys():
                 new_lower_bound = reaction_setup["lower_bound"]
                 model.reactions.get_by_id(reaction_to_set_up).lower_bound = (
@@ -265,6 +271,9 @@ def get_model_with_separated_measured_enzyme_reactions(
     print(all_measured_proteins)
     reaction_ids = [x.id for x in model.reactions]
     for reaction_id in reaction_ids:
+
+        print('splitting ' + reaction_id)
+
         reaction = model.reactions.get_by_id(reaction_id)
         if reaction.id not in reaction_id_gene_rules_mapping.keys():
             continue


### PR DESCRIPTION
The GPR rule of the original, unsplit reaction was used in every split reaction for isoenzymes with measured concentrations. This resulted in the GPR of the original reaction being used to assign pseudo metabolites for every split reaction. Should fix issue #12 and #33. Additionally, adds a guard that checks if GPR rules of isoenzymes are (or rules) are split correctly (#32).